### PR TITLE
feat: detect versions in more library filenames

### DIFF
--- a/main.js
+++ b/main.js
@@ -905,7 +905,7 @@ jsRefs.csv.onclick=()=>{ const rows=jh.findings.filter(f=>f.session===jh.session
   const vd = { findings: [], seen:new Set(), session:0, total:0, done:0, active:0 };
 
   const RX_VER = /\b(?:v|version[^\w]?|ver[^\w]?|release[^\w]?|build[^\w]?){0,1}\s*([0-9]+\.[0-9]+(?:\.[0-9]+){0,3}(?:[-_a-z0-9.]+)?)\b/gi;
-  const RX_FILE_VER = /(?:jquery|react|vue|angular|bootstrap|moment|lodash|underscore|d3|leaflet|three|ckeditor|tinymce|swiper|alpine|next|nuxt|webpack|tailwind|fontawesome|sentry|amplitude|mixpanel)[^\/]*?([0-9]+(?:\.[0-9]+){1,3})/i;
+  const RX_FILE_VER = /(?:jquery|react|vue|angular|bootstrap|moment|lodash|underscore|d3|leaflet|three|ckeditor|tinymce|swiper|alpine|next|nuxt|webpack|tailwind|fontawesome|sentry|amplitude|mixpanel|express|nestjs|chart|semantic|ember)[^\/]*?([0-9]+(?:\.[0-9]+){1,3})/i;
 
   function vdAdd(kind, tech, version, url, where, evidence, file, line){
     // Para headers dedup por host, no por URL específica


### PR DESCRIPTION
## Summary
- expand RX_FILE_VER regex to detect express, nestjs, chart, semantic, and ember libraries

## Testing
- `node - <<'NODE'
const RX_FILE_VER = /(?:jquery|react|vue|angular|bootstrap|moment|lodash|underscore|d3|leaflet|three|ckeditor|tinymce|swiper|alpine|next|nuxt|webpack|tailwind|fontawesome|sentry|amplitude|mixpanel|express|nestjs|chart|semantic|ember)[^\\/]*?([0-9]+(?:\\.[0-9]+){1,3})/i;
const samples = [
    'express-4.17.3.min.js',
    'nestjs.10.2.1.js',
    'chart-3.7.1.js',
    'semantic.min.2.4.2.css',
    'ember-3.28.5.js'
];
samples.forEach(s => {
    const m = s.match(RX_FILE_VER);
    console.log(s, '=>', m ? m[1] : null);
});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a4bf331c7483239f339eab9b694218