### PR TITLE
Inline chunk and TS secret scan in main script

### DIFF
--- a/test/chunk-ts-secrets.test.js
+++ b/test/chunk-ts-secrets.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const { scanChunksAndTs } = require('../main');
+
+const files = {
+  'app.chunk.js': "const apiKey = 'abc'; fetch('https://api.example.com/v1');",
+  'src/util.ts': "const password = 'p@ss'; const ip='192.168.0.1'; const dom='example.org';",
+  'main.js': "const token = 'ignored'; const url='http://ignored.com';",
+};
+
+const findings = scanChunksAndTs(files);
+
+assert.deepStrictEqual(findings, [
+  { file: 'app.chunk.js', type:'secret', match:'apiKey' },
+  { file: 'app.chunk.js', type:'endpoint', match:'https://api.example.com/v1' },
+  { file: 'src/util.ts', type:'secret', match:'password' },
+  { file: 'src/util.ts', type:'ip', match:'192.168.0.1' },
+  { file: 'src/util.ts', type:'domain', match:'example.org' }
+]);
+
+console.log('chunk and ts scan tests passed');


### PR DESCRIPTION
## Summary
- integrate chunk and TS scanner into main.js and remove standalone module
- detect endpoints, IPs, domains, and secrets
- update tests to use main.js export

## Testing
- `node test/buckets.test.js`
- `node test/highlightEnc.test.js`
- `node test/runtime-secrets.test.js`
- `node test/chunk-ts-secrets.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4ff752334832388ed0cde42bd6eac