### PR TITLE
Handle invalid encoded strings without logging errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -152,7 +152,6 @@ if (typeof window !== 'undefined') (function () {
           if (/[^\x20-\x7E]/.test(dec)) return b64;
           return `<span class="ptk-b64" title="${escHTML(dec)}">${b64}</span>`;
         } catch (_e) {
-          logError(_e);
           return b64;
         }
       });
@@ -165,7 +164,6 @@ if (typeof window !== 'undefined') (function () {
         const title = printable ? ` title="${escHTML(dec)}"` : '';
         return `<span class="ptk-hex"${title}>${hex}</span>`;
       } catch (_e) {
-        logError(_e);
         return hex;
       }
     });


### PR DESCRIPTION
## Summary
- avoid logging errors when highlightEnc encounters non-decodable base64 or hex strings

## Testing
- `node test/highlightEnc.test.js`
- `node test/chunk-ts-secrets.test.js`
- `node test/runtime-secrets.test.js`
- `node test/buckets.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a58804c1a083239b69eb57f227912a