### PR TITLE
feat: add global variable viewer

### DIFF
--- a/test/global-viewer.test.js
+++ b/test/global-viewer.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const { createGlobalViewer } = require('../main');
+
+function makeEl(tag){
+  return {
+    tag,
+    textContent: '',
+    children: [],
+    addEventListener(event, cb){ this['on'+event] = cb; },
+    appendChild(child){ this.children.push(child); },
+  };
+}
+
+global.document = {
+  body: makeEl('body'),
+  createElement: makeEl
+};
+
+  const base = new Set(Object.getOwnPropertyNames(global));
+  global.testNumber = 7;
+  global.testFunc = function(){ return 'ok'; };
+
+  const { container, output } = createGlobalViewer(global, base);
+
+  assert.deepStrictEqual(container.children.map(c=>c.textContent), ['testNumber','testFunc']);
+
+const btnNum = container.children.find(el => el.textContent === 'testNumber');
+btnNum.onclick();
+assert.strictEqual(output.textContent, '7');
+
+const btnFunc = container.children.find(el => el.textContent === 'testFunc');
+btnFunc.onclick();
+assert.strictEqual(output.textContent, JSON.stringify('ok', null, 2));
+
+console.log('global viewer tests passed');


### PR DESCRIPTION
## Summary
- Embed global viewer into main userscript and show buttons for page globals
- Filter out built-in globals and execute variable/function values on click
- Update tests to use new inlined viewer

## Testing
- `node test/buckets.test.js && node test/chunk-ts-secrets.test.js && node test/highlightEnc.test.js && node test/runtime-secrets.test.js && node test/global-viewer.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aba4eb6a0c8323a4f1f801121d7312